### PR TITLE
Add onNodeClick and onLinkClick handlers to MinSpanTree component and update Qmst page

### DIFF
--- a/src/components/MinSpanTree/MinSpanTree.css
+++ b/src/components/MinSpanTree/MinSpanTree.css
@@ -19,17 +19,44 @@
 }
 
 .qmst-text-container {
-  width: 50%; /* Set to 50% of the width */
-  padding: 20px;
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.qmst-columns {
+  display: flex;
+  justify-content: space-between;
+}
+
+.qmst-left-column {
+  flex: 1;
+}
+
+.qmst-right-column {
+  flex: 1;
+  margin-left: 20px;
 }
 
 .qmst-graph-container {
-  width: 50%; /* Set to 50% of the width */
+  width: 50%;
   padding: 20px;
 }
 
 .qmst-pre {
   white-space: pre-wrap;
   word-wrap: break-word;
+  border: 1px solid #ccc;
+  padding: 10px;
+  background-color: #f9f9f9;
+  border-radius: 5px;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.total-weight-container {
+  display: flex;
+  align-items: center;
+}
+
+.total-weight-container h4 {
+  margin-right: 10px;
 }

--- a/src/components/MinSpanTree/MinSpanTree.js
+++ b/src/components/MinSpanTree/MinSpanTree.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ForceGraph2D } from 'react-force-graph';
 import './MinSpanTree.css';
 
-const GraphComponent = ({ nodes, links, onNodeClick }) => {
+const GraphComponent = ({ nodes, links, onNodeClick, onLinkClick }) => {
   const graphRef = useRef();
   const [clickedNodes, setClickedNodes] = useState({});
   const [clickedLinks, setClickedLinks] = useState({});
@@ -29,6 +29,10 @@ const GraphComponent = ({ nodes, links, onNodeClick }) => {
       ...prevClickedLinks,
       [`${link.source.id}-${link.target.id}`]: !prevClickedLinks[`${link.source.id}-${link.target.id}`],
     }));
+
+    if (onLinkClick) {
+      onLinkClick(link); // Call onLinkClick handler passed from Qmst
+    }
   };
 
   return (

--- a/src/components/MinSpanTree/MinSpanTree.js
+++ b/src/components/MinSpanTree/MinSpanTree.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ForceGraph2D } from 'react-force-graph';
 import './MinSpanTree.css';
 
-const GraphComponent = ({ nodes, links }) => {
+const GraphComponent = ({ nodes, links, onNodeClick }) => {
   const graphRef = useRef();
   const [clickedNodes, setClickedNodes] = useState({});
   const [clickedLinks, setClickedLinks] = useState({});
@@ -19,6 +19,9 @@ const GraphComponent = ({ nodes, links }) => {
       ...prevClickedNodes,
       [node.id]: !prevClickedNodes[node.id],
     }));
+    if (onNodeClick) {
+      onNodeClick(node); // Call onNodeClick handler passed from Qmst
+    }
   };
 
   const handleLinkClick = (link) => {

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -38,6 +38,7 @@ const Qmst = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
   const [graphText, setGraphText] = useState('');
+  const [clickedNodes, setClickedNodes] = useState([]); // Store clicked nodes
 
   useEffect(() => {
     setIsModalOpen(true);
@@ -53,14 +54,27 @@ const Qmst = () => {
     setIsModalOpen(false);
   };
 
+  const handleNodeClick = (node) => {
+    setClickedNodes((prevNodes) => {
+      if (prevNodes.includes(node.id)) {
+        // Remove node if it's already clicked
+        return prevNodes.filter(n => n !== node.id);
+      } else {
+        // Add node if it's not clicked yet
+        return [...prevNodes, node.id];
+      }
+    });
+  };
+
   return (
     <div className="qmst-container">
       <div className="qmst-text-container">
         <h2>Preparation for Quiz QMST</h2>
         <pre className="qmst-pre">{graphText}</pre>
+        <div>Clicked Nodes: {clickedNodes.join(', ')}</div> {/* Display clicked nodes */}
       </div>
       <div className="qmst-graph-container">
-        <MinSpanTree nodes={graphData.nodes} links={graphData.links} />
+        <MinSpanTree nodes={graphData.nodes} links={graphData.links} onNodeClick={handleNodeClick} /> {/* Pass handler */}
       </div>
       <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
         <h2>Welcome to the Qmst Page!</h2>

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -38,7 +38,8 @@ const Qmst = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
   const [graphText, setGraphText] = useState('');
-  const [clickedNodes, setClickedNodes] = useState([]); // Store clicked nodes
+  const [clickedNodes, setClickedNodes] = useState([]);
+  const [clickedLinks, setClickedLinks] = useState([]); // Store clicked links and weights
 
   useEffect(() => {
     setIsModalOpen(true);
@@ -57,11 +58,20 @@ const Qmst = () => {
   const handleNodeClick = (node) => {
     setClickedNodes((prevNodes) => {
       if (prevNodes.includes(node.id)) {
-        // Remove node if it's already clicked
         return prevNodes.filter(n => n !== node.id);
       } else {
-        // Add node if it's not clicked yet
         return [...prevNodes, node.id];
+      }
+    });
+  };
+
+  const handleLinkClick = (link) => {
+    const linkInfo = `${link.source.id}-${link.target.id} (Weight: ${link.weight})`;
+    setClickedLinks((prevLinks) => {
+      if (prevLinks.includes(linkInfo)) {
+        return prevLinks.filter(l => l !== linkInfo);
+      } else {
+        return [...prevLinks, linkInfo];
       }
     });
   };
@@ -71,10 +81,16 @@ const Qmst = () => {
       <div className="qmst-text-container">
         <h2>Preparation for Quiz QMST</h2>
         <pre className="qmst-pre">{graphText}</pre>
-        <div>Clicked Nodes: {clickedNodes.join(', ')}</div> {/* Display clicked nodes */}
+        <div>Clicked Nodes: {clickedNodes.join(', ')}</div>
+        <div>Clicked Links: {clickedLinks.join(', ')}</div> {/* Display clicked links */}
       </div>
       <div className="qmst-graph-container">
-        <MinSpanTree nodes={graphData.nodes} links={graphData.links} onNodeClick={handleNodeClick} /> {/* Pass handler */}
+        <MinSpanTree
+          nodes={graphData.nodes}
+          links={graphData.links}
+          onNodeClick={handleNodeClick}
+          onLinkClick={handleLinkClick} // Pass the link click handler
+        />
       </div>
       <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
         <h2>Welcome to the Qmst Page!</h2>

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -16,7 +16,7 @@ const generateGraphData = (numNodes) => {
 
   for (let i = 0; i < limitedNumNodes; i++) {
     for (let j = i + 1; j < limitedNumNodes; j++) {
-      const weight = Math.floor(Math.random() * 20) + 1;
+      const weight = Math.floor(Math.random() * 30) + 1;
       links.push({
         source: nodes[i].id,
         target: nodes[j].id,
@@ -38,8 +38,9 @@ const Qmst = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [graphData, setGraphData] = useState({ nodes: [], links: [] });
   const [graphText, setGraphText] = useState('');
-  const [clickedNodes, setClickedNodes] = useState([]);
-  const [clickedLinks, setClickedLinks] = useState([]); // Store clicked links and weights
+  const [clickedVertices, setClickedVertices] = useState([]);
+  const [clickedEdges, setClickedEdges] = useState([]);
+  const [totalWeight, setTotalWeight] = useState(0);
 
   useEffect(() => {
     setIsModalOpen(true);
@@ -55,8 +56,8 @@ const Qmst = () => {
     setIsModalOpen(false);
   };
 
-  const handleNodeClick = (node) => {
-    setClickedNodes((prevNodes) => {
+  const handleVertxClick = (node) => {
+    setClickedVertices((prevNodes) => {
       if (prevNodes.includes(node.id)) {
         return prevNodes.filter(n => n !== node.id);
       } else {
@@ -65,14 +66,24 @@ const Qmst = () => {
     });
   };
 
-  const handleLinkClick = (link) => {
+  const handleEdgeClick = (link) => {
     const linkInfo = `${link.source.id}-${link.target.id} (Weight: ${link.weight})`;
-    setClickedLinks((prevLinks) => {
+    
+    setClickedEdges((prevLinks) => {
+      let updatedLinks;
       if (prevLinks.includes(linkInfo)) {
-        return prevLinks.filter(l => l !== linkInfo);
+        updatedLinks = prevLinks.filter(l => l !== linkInfo);
       } else {
-        return [...prevLinks, linkInfo];
+        updatedLinks = [...prevLinks, linkInfo];
       }
+
+      const updatedTotalWeight = updatedLinks.reduce((sum, l) => {
+        const weight = parseInt(l.match(/\(Weight: (\d+)\)/)[1], 10);
+        return sum + weight;
+      }, 0);
+
+      setTotalWeight(updatedTotalWeight);
+      return updatedLinks;
     });
   };
 
@@ -81,15 +92,33 @@ const Qmst = () => {
       <div className="qmst-text-container">
         <h2>Preparation for Quiz QMST</h2>
         <pre className="qmst-pre">{graphText}</pre>
-        <div>Clicked Nodes: {clickedNodes.join(', ')}</div>
-        <div>Clicked Links: {clickedLinks.join(', ')}</div> {/* Display clicked links */}
+        <div className="qmst-columns">
+          <div className="qmst-left-column">
+            <h4>Clicked Vertices:</h4>
+            <p style={{ textAlign: 'left' }}>{clickedVertices.join(', ')}</p>
+
+            <h4>Clicked Edges:</h4>
+            <ul>
+              {clickedEdges.map((link, index) => (
+                <li key={index}>{link}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="qmst-right-column">
+            <div className='total-weight-container'>
+              <h4>Total Weight (Auto-Calculated):</h4>
+              <p>{totalWeight}</p>
+            </div>
+          </div>
+        </div>
       </div>
       <div className="qmst-graph-container">
         <MinSpanTree
           nodes={graphData.nodes}
           links={graphData.links}
-          onNodeClick={handleNodeClick}
-          onLinkClick={handleLinkClick} // Pass the link click handler
+          onNodeClick={handleVertxClick}
+          onLinkClick={handleEdgeClick}
         />
       </div>
       <Modal isOpen={isModalOpen} onClose={handleCloseModal}>


### PR DESCRIPTION
"This pull request adds the `onNodeClick` and `onLinkClick` handlers to the `MinSpanTree` component, allowing for interaction with the graph nodes and links. It also updates the `Qmst` page to generate random graph data with an increased weight range. Additionally, the CSS for the `MinSpanTree` component is refactored to center the graph container. The `Qmst` page now displays the clicked vertices and edges, and calculates the total weight of the clicked edges. These changes enhance the functionality and user experience of the Qmst page."