### PR TITLE
Refactor Qmst page to improve graph generation and display

### DIFF
--- a/src/components/MinSpanTree/MinSpanTree.js
+++ b/src/components/MinSpanTree/MinSpanTree.js
@@ -2,10 +2,17 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ForceGraph2D } from 'react-force-graph';
 import './MinSpanTree.css';
 
-const GraphComponent = ({ nodes, links, onNodeClick, onLinkClick }) => {
+const GraphComponent = ({ nodes, links, onNodeClick, onLinkClick, resetGraph }) => {
   const graphRef = useRef();
   const [clickedNodes, setClickedNodes] = useState({});
   const [clickedLinks, setClickedLinks] = useState({});
+
+  useEffect(() => {
+    if (resetGraph) {
+      setClickedNodes({});
+      setClickedLinks({});
+    }
+  }, [resetGraph]);
 
   useEffect(() => {
     const graph = graphRef.current;

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -104,6 +104,7 @@ const Qmst = () => {
   const [totalWeight, setTotalWeight] = useState(0);
   const [correctMstWeight, setCorrectMstWeight] = useState(null);
   const [showAnswer, setShowAnswer] = useState(false);
+  const [resetGraph, setResetGraph] = useState(null);
 
   useEffect(() => {
     setIsModalOpen(true);
@@ -112,13 +113,14 @@ const Qmst = () => {
 
   const generateNewGraph = () => {
     const { nodes, links } = generateGraphData(6);
-    console.log(JSON.stringify(nodes), JSON.stringify(links));
     setGraphData({ nodes, links });
     const formattedText = formatGraphText(nodes, links);
     setGraphText(formattedText);
     setClickedVertices([]);
     setClickedEdges([]);
     setTotalWeight(0);
+
+    setResetGraph(Date.now());
 
     const { totalWeight: mstTotalWeight } = findMST({ nodes, links });
     setCorrectMstWeight(mstTotalWeight);
@@ -220,6 +222,7 @@ const Qmst = () => {
           links={graphData.links}
           onNodeClick={handleVertxClick}
           onLinkClick={handleEdgeClick}
+          resetGraph={resetGraph}
         />
       </div>
       <Modal isOpen={isModalOpen} onClose={handleCloseModal}>

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -3,6 +3,67 @@ import MinSpanTree from '../components/MinSpanTree/MinSpanTree';
 import Modal from '../components/Modal/Modal';
 import '../components/MinSpanTree/MinSpanTree.css';
 
+class UnionFind {
+  constructor(size) {
+    this.parent = Array.from({ length: size }, (_, i) => i);
+    this.rank = Array(size).fill(0);
+  }
+
+  find(node) {
+    if (this.parent[node] !== node) {
+      this.parent[node] = this.find(this.parent[node]);
+    }
+    return this.parent[node];
+  }
+
+  union(node1, node2) {
+    const root1 = this.find(node1);
+    const root2 = this.find(node2);
+
+    if (root1 !== root2) {
+      if (this.rank[root1] > this.rank[root2]) {
+        this.parent[root2] = root1;
+      } else if (this.rank[root1] < this.rank[root2]) {
+        this.parent[root1] = root2;
+      } else {
+        this.parent[root2] = root1;
+        this.rank[root1]++;
+      }
+    }
+  }
+}
+
+const findMST = (graph) => {
+  const { nodes, links } = graph;
+  const nodeIndexMap = {};
+  nodes.forEach((node, index) => {
+    nodeIndexMap[node.id] = index;
+  });
+
+  links.sort((a, b) => a.weight - b.weight);
+
+  const uf = new UnionFind(nodes.length);
+  const mstLinks = [];
+  let totalWeight = 0;
+
+  for (const link of links) {
+    const sourceIndex = nodeIndexMap[link.source];
+    const targetIndex = nodeIndexMap[link.target];
+
+    if (uf.find(sourceIndex) !== uf.find(targetIndex)) {
+      uf.union(sourceIndex, targetIndex);
+      mstLinks.push(link);
+      totalWeight += link.weight;
+
+      if (mstLinks.length === nodes.length - 1) {
+        break;
+      }
+    }
+  }
+
+  return { mstLinks, totalWeight };
+};
+
 const generateGraphData = (numNodes) => {
   const nodes = [];
   const links = [];
@@ -41,16 +102,28 @@ const Qmst = () => {
   const [clickedVertices, setClickedVertices] = useState([]);
   const [clickedEdges, setClickedEdges] = useState([]);
   const [totalWeight, setTotalWeight] = useState(0);
+  const [correctMstWeight, setCorrectMstWeight] = useState(null);
+  const [showAnswer, setShowAnswer] = useState(false);
 
   useEffect(() => {
     setIsModalOpen(true);
+    generateNewGraph();
+  }, []);
 
+  const generateNewGraph = () => {
     const { nodes, links } = generateGraphData(6);
+    console.log(JSON.stringify(nodes), JSON.stringify(links));
     setGraphData({ nodes, links });
-
     const formattedText = formatGraphText(nodes, links);
     setGraphText(formattedText);
-  }, []);
+    setClickedVertices([]);
+    setClickedEdges([]);
+    setTotalWeight(0);
+
+    const { totalWeight: mstTotalWeight } = findMST({ nodes, links });
+    setCorrectMstWeight(mstTotalWeight);
+    setShowAnswer(false);
+  };
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
@@ -68,7 +141,7 @@ const Qmst = () => {
 
   const handleEdgeClick = (link) => {
     const linkInfo = `${link.source.id}-${link.target.id} (Weight: ${link.weight})`;
-    
+
     setClickedEdges((prevLinks) => {
       let updatedLinks;
       if (prevLinks.includes(linkInfo)) {
@@ -87,11 +160,39 @@ const Qmst = () => {
     });
   };
 
+  const handleShowAnswer = () => {
+    if (correctMstWeight !== null) {
+      setTotalWeight(correctMstWeight);
+      setShowAnswer(true);
+    }
+  };
+
   return (
     <div className="qmst-container">
       <div className="qmst-text-container">
         <h2>Preparation for Quiz QMST</h2>
         <pre className="qmst-pre">{graphText}</pre>
+        <div className="button-container" style={{ display: 'flex', justifyContent: 'center', gap: '10px' }}>
+          <button
+            className='styled-button'
+            style={{ width: '167.17px' }}
+            onClick={generateNewGraph}
+          >
+            Generate New
+          </button>
+          {!showAnswer && (
+            <button
+              className='styled-button'
+              style={{ width: '167.17px' }}
+              onClick={handleShowAnswer}
+            >
+              Show Answer
+            </button>
+          )}
+        </div>
+        {showAnswer && (
+          <h3 style={{ textAlign: 'center' }}>Total Weight: {correctMstWeight}</h3>
+        )}
         <div className="qmst-columns">
           <div className="qmst-left-column">
             <h4>Clicked Vertices:</h4>

--- a/src/pages/Qmst.js
+++ b/src/pages/Qmst.js
@@ -162,7 +162,7 @@ const Qmst = () => {
 
   const handleShowAnswer = () => {
     if (correctMstWeight !== null) {
-      setTotalWeight(correctMstWeight);
+      setCorrectMstWeight(correctMstWeight);
       setShowAnswer(true);
     }
   };
@@ -191,7 +191,7 @@ const Qmst = () => {
           )}
         </div>
         {showAnswer && (
-          <h3 style={{ textAlign: 'center' }}>Total Weight: {correctMstWeight}</h3>
+          <h3 className={totalWeight === correctMstWeight ? 'correct' : 'incorrect'} style={{ textAlign: 'center' }}>Total Weight: {correctMstWeight}</h3>
         )}
         <div className="qmst-columns">
           <div className="qmst-left-column">


### PR DESCRIPTION
This pull request includes several refactorings to the Qmst page. The first commit updates the Qmst page to generate random graph data with an increased weight range. The second commit updates the Qmst page to display the total weight with correct/incorrect styling. The third and fourth commits reset the clicked nodes and clicked links when the resetGraph prop is true. These changes improve the functionality and user experience of the Qmst page.