### PR TITLE
Add 404 page for handling non-existent routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import Qbst from './pages/Qbst';
 import Qqp from './pages/Qqp';
 import Qhuf from './pages/Qhuf';
 import Qmst from './pages/Qmst';
+import NotFound from './pages/NotFound';
 import './App.css';
 
 const App = () => {
@@ -29,6 +30,7 @@ const App = () => {
             <Route path="/longest-common-subsequence" element={<Qlcs />} />
             <Route path="/huffman-encoding" element={<Qhuf />} />
             <Route path="/minimum-spanning-tree" element={<Qmst />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
         <Footer />

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NotFound = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h1>404 - Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
+      <Link to="/" className='styled-button'>Go back to Home</Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
This pull request adds a 404 page for handling non-existent routes. It includes a new component called NotFound that displays a "404 - Page Not Found" message and provides a link to go back to the home page.